### PR TITLE
Update fly api to accept mac address

### DIFF
--- a/server.py
+++ b/server.py
@@ -21,7 +21,8 @@ def root():
 def fly():
     data = request.get_json()
     program = data['body']['body']['program']
-    xdrone.fly(program)
+    address = data['body']['body']['address']
+    xdrone.fly(program, address)
     return "Flight success"
 
 


### PR DESCRIPTION
The xdrone.fly function had a mac address parameter already, with a default value
that we always used. Now, I'm expecting an "address" field in the post
request that gets passed to xdrone.fly

To be merged once the MM is updated to actually send the mac address too.